### PR TITLE
chore: upgrade to net10.0-android and add NuGet packaging metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ CodeCoverage/
 # NUnit
 *.VisualState.xml
 TestResult.xml
-nunit-*.xml
+nunit-*.xmlsrc/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xmlsrc/.idea/
+
+# JetBrains Rider
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## 项目简介
 
-`GeneralUpdate.Avalonia` 是面向 Avalonia 应用的更新能力仓库。当前核心模块为 `GeneralUpdate.Avalonia.Android`，提供 Android 平台自动更新流程编排能力（无 UI），适配 `net8.0-android`，面向 Avalonia 12+ 应用。
+`GeneralUpdate.Avalonia` 是面向 Avalonia 应用的更新能力仓库。当前核心模块为 `GeneralUpdate.Avalonia.Android`，提供 Android 平台自动更新流程编排能力（无 UI），适配 `net10.0-android`，面向 Avalonia 12+ 应用。
 
 项目将更新流程拆分为可组合的抽象接口，便于在不同业务场景下替换版本比较、下载、哈希校验、安装拉起、日志与事件分发实现。
 
@@ -25,8 +25,8 @@
 
 ### 环境准备
 
-- .NET SDK：`8.0+`（推荐 `10.0+`）
-- 平台：`Android (net10.0-android)` 或 `net8.0-android`
+- .NET SDK：`10.0+`
+- 平台：`Android (net10.0-android)`
 - Avalonia：`12+`
 - Git：`2.30+`
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 
 ### 环境准备
 
-- .NET SDK：`8.0+`
-- 平台：`Android (net8.0-android)`
+- .NET SDK：`8.0+`（推荐 `10.0+`）
+- 平台：`Android (net10.0-android)` 或 `net8.0-android`
 - Avalonia：`12+`
 - Git：`2.30+`
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.418",
-    "rollForward": "latestFeature"
+    "version": "8.0.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/src/GeneralUpdate.Avalonia.Android/GeneralUpdate.Avalonia.Android.csproj
+++ b/src/GeneralUpdate.Avalonia.Android/GeneralUpdate.Avalonia.Android.csproj
@@ -1,19 +1,42 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-android34.0</TargetFramework>
-    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+    <TargetFramework>net10.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>26.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+
+    <!-- Pack settings -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>GeneralUpdate.Avalonia.Android</PackageId>
-    <Description>UI-free, Avalonia-compatible Android auto-update core library.</Description>
+    <Version>1.0.0</Version>
+    <Description>UI-free, Avalonia-compatible Android auto-update core library. Provides version comparison, resumable APK download with SHA256 verification, and APK installation orchestration.</Description>
     <Authors>GeneralLibrary</Authors>
+    <Copyright>Copyright (c) GeneralLibrary</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/GeneralLibrary/GeneralUpdate.Avalonia</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GeneralLibrary/GeneralUpdate.Avalonia</RepositoryUrl>
-    <PackageTags>avalonia;android;update;apk;autoupdate</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>avalonia;android;update;apk;autoupdate;generalupdate</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>https://github.com/GeneralLibrary/GeneralUpdate.Avalonia/releases</PackageReleaseNotes>
+
+    <!-- SourceLink support -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+    <!-- Deterministic build for CI -->
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Core" Version="1.13.1.2" />
+  </ItemGroup>
+
+  <!-- Include README in the package -->
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/GeneralUpdate.Avalonia.Android/GeneralUpdate.Avalonia.Android.csproj
+++ b/src/GeneralUpdate.Avalonia.Android/GeneralUpdate.Avalonia.Android.csproj
@@ -32,6 +32,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Core" Version="1.13.1.2" />
   </ItemGroup>
 

--- a/src/GeneralUpdate.Avalonia.slnx
+++ b/src/GeneralUpdate.Avalonia.slnx
@@ -1,0 +1,5 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="GeneralUpdate.Avalonia.Android/GeneralUpdate.Avalonia.Android.csproj" />
+  </Folder>
+</Solution>

--- a/tests/GeneralUpdate.Avalonia.Android.Tests/GeneralUpdate.Avalonia.Android.Tests.csproj
+++ b/tests/GeneralUpdate.Avalonia.Android.Tests/GeneralUpdate.Avalonia.Android.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Closes #12

## Summary
Prepares `GeneralUpdate.Avalonia.Android` for NuGet publishing by adding proper packaging metadata and upgrading to .NET 10.

## Key changes
- Upgrade TFM from `net8.0-android34.0` to `net10.0-android`
- Add full NuGet packaging metadata
- Add `src/GeneralUpdate.Avalonia.slnx`
- Fix SupportedOSPlatformVersion to 26

## Verification
- [x] Builds with 0 errors
- [x] Generates `.nupkg` and `.snupkg` outputs
- [x] Tests build and pass