### PR TITLE
feat: add HTTP/HTTPS compatibility and multiple authentication methods

### DIFF
--- a/src/GeneralUpdate.Avalonia.Android/Abstractions/IHttpAuthProvider.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Abstractions/IHttpAuthProvider.cs
@@ -1,0 +1,11 @@
+namespace GeneralUpdate.Avalonia.Android.Abstractions;
+
+/// <summary>
+/// Provides authentication for HTTP requests.
+/// Implementations can add headers, modify the request, or perform
+/// any other authentication flow before the request is sent.
+/// </summary>
+public interface IHttpAuthProvider
+{
+    Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default);
+}

--- a/src/GeneralUpdate.Avalonia.Android/Abstractions/ISslValidationPolicy.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Abstractions/ISslValidationPolicy.cs
@@ -1,0 +1,16 @@
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace GeneralUpdate.Avalonia.Android.Abstractions;
+
+/// <summary>
+/// Provides custom SSL/TLS certificate validation logic.
+/// Used to configure <see cref="System.Net.Http.HttpClientHandler.ServerCertificateCustomValidationCallback"/>.
+/// </summary>
+public interface ISslValidationPolicy
+{
+    bool ValidateCertificate(
+        X509Certificate2? certificate,
+        X509Chain? chain,
+        SslPolicyErrors sslPolicyErrors);
+}

--- a/src/GeneralUpdate.Avalonia.Android/Enums/AuthScheme.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Enums/AuthScheme.cs
@@ -1,0 +1,28 @@
+namespace GeneralUpdate.Avalonia.Android.Enums;
+
+/// <summary>
+/// Defines the supported HTTP authentication schemes for update downloads.
+/// </summary>
+public enum AuthScheme
+{
+    /// <summary>
+    /// HMAC-SHA256 signature-based authentication.
+    /// Adds X-Update-Timestamp and X-Update-Signature headers.
+    /// </summary>
+    Hmac = 0,
+
+    /// <summary>
+    /// Bearer token authentication via Authorization header.
+    /// </summary>
+    Bearer = 1,
+
+    /// <summary>
+    /// API key authentication via a custom header (default: X-Api-Key).
+    /// </summary>
+    ApiKey = 2,
+
+    /// <summary>
+    /// HTTP Basic authentication via Authorization header.
+    /// </summary>
+    Basic = 3
+}

--- a/src/GeneralUpdate.Avalonia.Android/GeneralUpdateBootstrap.cs
+++ b/src/GeneralUpdate.Avalonia.Android/GeneralUpdateBootstrap.cs
@@ -14,7 +14,8 @@ public static class GeneralUpdateBootstrap
         HttpClient? httpClient = null,
         IVersionComparer? versionComparer = null,
         IUpdateEventDispatcher? eventDispatcher = null,
-        IUpdateLogger? logger = null)
+        IUpdateLogger? logger = null,
+        HttpDownloadOptions? httpOptions = null)
     {
         var usedContextProvider = contextProvider ?? new DefaultAndroidContextProvider();
         var context = usedContextProvider.GetContext();
@@ -32,9 +33,22 @@ public static class GeneralUpdateBootstrap
         var effectiveOptions = options with { DownloadDirectoryPath = effectiveDownloadDirectory };
         var usedLogger = logger ?? new NoOpUpdateLogger();
         var usedStorage = new PhysicalFileStorage();
-        var usedClient = httpClient ?? new HttpClient();
 
-        var downloader = new HttpResumableApkDownloader(usedClient, usedStorage, effectiveOptions, usedLogger);
+        HttpResumableApkDownloader downloader;
+        if (httpOptions != null)
+        {
+            // Use internal constructor that builds HttpClient from HttpDownloadOptions
+            // (SSL validation, proxy, auth, timeouts)
+            downloader = new HttpResumableApkDownloader(
+                usedStorage, effectiveOptions, httpOptions, usedLogger);
+        }
+        else
+        {
+            // Legacy path: use injected httpClient or a bare new one
+            var usedClient = httpClient ?? new HttpClient();
+            downloader = new HttpResumableApkDownloader(
+                usedClient, usedStorage, effectiveOptions, usedLogger);
+        }
         var validator = new Sha256HashValidator();
         var installer = new AndroidApkInstaller(
             usedContextProvider,

--- a/src/GeneralUpdate.Avalonia.Android/Models/HttpDownloadOptions.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Models/HttpDownloadOptions.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using GeneralUpdate.Avalonia.Android.Abstractions;
+
+namespace GeneralUpdate.Avalonia.Android.Models;
+
+/// <summary>
+/// Configures HTTP transport behavior for update downloads:
+/// SSL/TLS certificate validation, timeouts, proxy, retry, and authentication.
+/// <para>
+/// When provided to <see cref="GeneralUpdateBootstrap.CreateDefault"/>,
+/// the library constructs an internal <see cref="HttpClient"/> from these settings.
+/// When null, the existing behavior is preserved (bare HttpClient, no auth, system SSL).
+/// </para>
+/// </summary>
+public sealed record HttpDownloadOptions
+{
+    /// <summary>
+    /// Custom SSL/TLS certificate validation policy.
+    /// Defaults to null, which uses the system's default certificate validation.
+    /// Set to <see cref="Services.AllowAllSslValidationPolicy"/> for self-signed certificates
+    /// in development environments only.
+    /// </summary>
+    public ISslValidationPolicy? SslValidationPolicy { get; init; }
+
+    /// <summary>
+    /// Timeout for individual HTTP requests (HEAD probes, etc.).
+    /// Default is 30 seconds.
+    /// </summary>
+    public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Overall timeout for the entire download operation.
+    /// Default is 10 minutes.
+    /// </summary>
+    public TimeSpan DownloadTimeout { get; init; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Optional web proxy for HTTP requests.
+    /// When set, <see cref="UseProxy"/> must also be true for the proxy to take effect.
+    /// </summary>
+    public IWebProxy? Proxy { get; init; }
+
+    /// <summary>
+    /// Whether to use the configured <see cref="Proxy"/>.
+    /// Default is false.
+    /// </summary>
+    public bool UseProxy { get; init; }
+
+    /// <summary>
+    /// Maximum number of retry attempts for transient failures.
+    /// Default is 3 (meaning 1 initial attempt + 2 retries).
+    /// Set to 1 to disable retry.
+    /// </summary>
+    public int MaxRetryAttempts { get; init; } = 3;
+
+    /// <summary>
+    /// Base delay for exponential backoff retry.
+    /// Actual delays are: baseDelay * 2^attempt.
+    /// Default is 1 second.
+    /// </summary>
+    public TimeSpan RetryBaseDelay { get; init; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Global authentication provider applied to all download requests.
+    /// Per-package authentication on <see cref="UpdatePackageInfo"/> takes precedence.
+    /// </summary>
+    public IHttpAuthProvider? AuthProvider { get; init; }
+
+    /// <summary>
+    /// Builds an <see cref="HttpClientHandler"/> from the configured options.
+    /// Applies SSL validation policy and proxy settings.
+    /// </summary>
+    internal HttpClientHandler BuildHandler()
+    {
+        var handler = new HttpClientHandler();
+
+        if (SslValidationPolicy != null)
+        {
+            handler.ServerCertificateCustomValidationCallback =
+                (_, cert, chain, errors) => SslValidationPolicy.ValidateCertificate(cert, chain, errors);
+        }
+
+        if (UseProxy && Proxy != null)
+        {
+            handler.Proxy = Proxy;
+            handler.UseProxy = true;
+        }
+        else
+        {
+            handler.UseProxy = false;
+        }
+
+        return handler;
+    }
+}

--- a/src/GeneralUpdate.Avalonia.Android/Models/UpdatePackageInfo.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Models/UpdatePackageInfo.cs
@@ -1,3 +1,5 @@
+using GeneralUpdate.Avalonia.Android.Enums;
+
 namespace GeneralUpdate.Avalonia.Android.Models;
 
 public sealed record UpdatePackageInfo
@@ -11,4 +13,32 @@ public sealed record UpdatePackageInfo
     public DateTimeOffset? PublishTime { get; init; }
     public bool IsForced { get; init; }
     public string? FileName { get; init; }
+
+    /// <summary>
+    /// Per-package authentication scheme.
+    /// When set, takes precedence over the global <see cref="HttpDownloadOptions.AuthProvider"/>.
+    /// </summary>
+    public Enums.AuthScheme? AuthScheme { get; init; }
+
+    /// <summary>
+    /// Token value used by Bearer or ApiKey authentication.
+    /// For Bearer: the Bearer token string.
+    /// For ApiKey: the API key value.
+    /// </summary>
+    public string? AuthToken { get; init; }
+
+    /// <summary>
+    /// Secret key used by HMAC-SHA256 signature authentication.
+    /// </summary>
+    public string? AuthSecretKey { get; init; }
+
+    /// <summary>
+    /// Username used by Basic authentication.
+    /// </summary>
+    public string? BasicUsername { get; init; }
+
+    /// <summary>
+    /// Password used by Basic authentication.
+    /// </summary>
+    public string? BasicPassword { get; init; }
 }

--- a/src/GeneralUpdate.Avalonia.Android/Models/UpdatePackageInfo.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Models/UpdatePackageInfo.cs
@@ -18,7 +18,7 @@ public sealed record UpdatePackageInfo
     /// Per-package authentication scheme.
     /// When set, takes precedence over the global <see cref="HttpDownloadOptions.AuthProvider"/>.
     /// </summary>
-    public Enums.AuthScheme? AuthScheme { get; init; }
+    public AuthScheme? AuthScheme { get; init; }
 
     /// <summary>
     /// Token value used by Bearer or ApiKey authentication.

--- a/src/GeneralUpdate.Avalonia.Android/Services/AndroidBootstrap.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Services/AndroidBootstrap.cs
@@ -282,6 +282,12 @@ public sealed class AndroidBootstrap : IAndroidBootstrap
         }
 
         _operationGate.Dispose();
+
+        if (_downloader is IDisposable disposableDownloader)
+        {
+            disposableDownloader.Dispose();
+        }
+
         _disposed = true;
     }
 

--- a/src/GeneralUpdate.Avalonia.Android/Services/AuthProviders.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Services/AuthProviders.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using GeneralUpdate.Avalonia.Android.Abstractions;
+using GeneralUpdate.Avalonia.Android.Enums;
+
+namespace GeneralUpdate.Avalonia.Android.Services;
+
+/// <summary>
+/// No-op authentication provider. Does not modify the request.
+/// Used as the default when no authentication is configured.
+/// </summary>
+public sealed class NoOpAuthProvider : IHttpAuthProvider
+{
+    public Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default)
+        => Task.CompletedTask;
+}
+
+/// <summary>
+/// Bearer token authentication provider.
+/// Adds <c>Authorization: Bearer &lt;token&gt;</c> header to the request.
+/// </summary>
+public sealed class BearerTokenAuthProvider : IHttpAuthProvider
+{
+    private readonly string _token;
+
+    public BearerTokenAuthProvider(string token)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+#else
+        if (string.IsNullOrWhiteSpace(token))
+            throw new ArgumentException("Token cannot be null or whitespace.", nameof(token));
+#endif
+        _token = token;
+    }
+
+    public Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// API key authentication provider.
+/// Adds a custom header (default: <c>X-Api-Key</c>) with the API key value.
+/// </summary>
+public sealed class ApiKeyAuthProvider : IHttpAuthProvider
+{
+    private readonly string _apiKey;
+    private readonly string _headerName;
+
+    public ApiKeyAuthProvider(string apiKey, string headerName = "X-Api-Key")
+    {
+#if NET6_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(headerName);
+#else
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new ArgumentException("API key cannot be null or whitespace.", nameof(apiKey));
+        if (string.IsNullOrWhiteSpace(headerName))
+            throw new ArgumentException("Header name cannot be null or whitespace.", nameof(headerName));
+#endif
+        _apiKey = apiKey;
+        _headerName = headerName;
+    }
+
+    public Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default)
+    {
+        request.Headers.Remove(_headerName);
+        request.Headers.Add(_headerName, _apiKey);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// HTTP Basic authentication provider.
+/// Adds <c>Authorization: Basic &lt;base64&gt;</c> header to the request.
+/// </summary>
+public sealed class BasicAuthProvider : IHttpAuthProvider
+{
+    private readonly string _credential;
+
+    public BasicAuthProvider(string credential)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrWhiteSpace(credential);
+#else
+        if (string.IsNullOrWhiteSpace(credential))
+            throw new ArgumentException("Credential cannot be null or whitespace.", nameof(credential));
+#endif
+        _credential = credential;
+    }
+
+    /// <summary>
+    /// Creates a Basic authentication header value from username and password.
+    /// </summary>
+    public static string EncodeCredential(string username, string password)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrWhiteSpace(username);
+#else
+        if (string.IsNullOrWhiteSpace(username))
+            throw new ArgumentException("Username cannot be null or whitespace.", nameof(username));
+#endif
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password ?? string.Empty}"));
+    }
+
+    /// <summary>
+    /// Creates a BasicAuthProvider from username and password credentials.
+    /// </summary>
+    public static BasicAuthProvider FromCredentials(string username, string password)
+        => new BasicAuthProvider(EncodeCredential(username, password));
+
+    public Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", _credential);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// HMAC-SHA256 signature authentication provider.
+/// Adds <c>X-Update-Timestamp</c> and <c>X-Update-Signature</c> headers.
+/// The signature is computed as HMACSHA256 over <c>body|timestamp</c> using the secret key.
+/// </summary>
+public sealed class HmacAuthProvider : IHttpAuthProvider
+{
+    private readonly string _secretKey;
+
+    public HmacAuthProvider(string secretKey)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretKey);
+#else
+        if (string.IsNullOrWhiteSpace(secretKey))
+            throw new ArgumentException("Secret key cannot be null or whitespace.", nameof(secretKey));
+#endif
+        _secretKey = secretKey;
+    }
+
+    public async Task ApplyAuthAsync(HttpRequestMessage request, CancellationToken token = default)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
+        var body = string.Empty;
+
+        if (request.Content != null)
+        {
+            body = await request.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+        }
+
+        var message = $"{body}|{timestamp}";
+        var keyBytes = Encoding.UTF8.GetBytes(_secretKey);
+
+#if NET6_0_OR_GREATER
+        var hash = HMACSHA256.HashData(keyBytes, Encoding.UTF8.GetBytes(message));
+#else
+        using var hmac = new HMACSHA256(keyBytes);
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+#endif
+        var signature = Convert.ToHexString(hash).ToLowerInvariant();
+
+        request.Headers.Remove("X-Update-Timestamp");
+        request.Headers.Remove("X-Update-Signature");
+        request.Headers.Add("X-Update-Timestamp", timestamp);
+        request.Headers.Add("X-Update-Signature", signature);
+    }
+}
+
+/// <summary>
+/// Factory for creating <see cref="IHttpAuthProvider"/> instances
+/// based on the specified authentication scheme and credentials.
+/// </summary>
+public static class HttpAuthProviderFactory
+{
+    /// <summary>
+    /// Creates an <see cref="IHttpAuthProvider"/> from an <see cref="AuthScheme"/> with the given credentials.
+    /// Returns <see cref="NoOpAuthProvider"/> when scheme is null or unrecognized.
+    /// </summary>
+    public static IHttpAuthProvider Create(
+        AuthScheme? scheme,
+        string? token = null,
+        string? secretKey = null,
+        string? basicUsername = null,
+        string? basicPassword = null)
+    {
+        return scheme switch
+        {
+            AuthScheme.Bearer when !string.IsNullOrWhiteSpace(token)
+                => new BearerTokenAuthProvider(token),
+            AuthScheme.ApiKey when !string.IsNullOrWhiteSpace(token)
+                => new ApiKeyAuthProvider(token),
+            AuthScheme.Basic when !string.IsNullOrWhiteSpace(basicUsername)
+                => BasicAuthProvider.FromCredentials(basicUsername, basicPassword ?? string.Empty),
+            AuthScheme.Hmac when !string.IsNullOrWhiteSpace(secretKey)
+                => new HmacAuthProvider(secretKey),
+            _ => new NoOpAuthProvider()
+        };
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IHttpAuthProvider"/> from a string-based scheme identifier
+    /// with the given credentials. Supports "bearer", "apikey", "basic", "hmac" (case-insensitive).
+    /// Returns <see cref="NoOpAuthProvider"/> when scheme is null or unrecognized.
+    /// </summary>
+    public static IHttpAuthProvider Create(
+        string? scheme,
+        string? token = null,
+        string? secretKey = null,
+        string? basicUsername = null,
+        string? basicPassword = null)
+    {
+        if (string.IsNullOrWhiteSpace(scheme))
+            return new NoOpAuthProvider();
+
+        return scheme.ToLowerInvariant() switch
+        {
+            "bearer" when !string.IsNullOrWhiteSpace(token)
+                => new BearerTokenAuthProvider(token),
+            "apikey" when !string.IsNullOrWhiteSpace(token)
+                => new ApiKeyAuthProvider(token),
+            "basic" when !string.IsNullOrWhiteSpace(basicUsername)
+                => BasicAuthProvider.FromCredentials(basicUsername, basicPassword ?? string.Empty),
+            "hmac" when !string.IsNullOrWhiteSpace(secretKey)
+                => new HmacAuthProvider(secretKey),
+            _ => new NoOpAuthProvider()
+        };
+    }
+}

--- a/src/GeneralUpdate.Avalonia.Android/Services/HttpResumableApkDownloader.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Services/HttpResumableApkDownloader.cs
@@ -34,6 +34,7 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader, IDisposable
         _logger = logger ?? new NoOpUpdateLogger();
         _httpOptions = null;
         _globalAuthProvider = null;
+        _ownsClient = false;
     }
 
     /// <summary>
@@ -48,7 +49,11 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader, IDisposable
         _logger = logger ?? new NoOpUpdateLogger();
 
         var handler = httpOptions.BuildHandler();
-        _httpClient = new HttpClient(handler, disposeHandler: true);
+        _httpClient = new HttpClient(handler, disposeHandler: true)
+        {
+            // Timeout is managed per-request via CancellationTokenSource linked to DownloadTimeout
+            Timeout = System.Threading.Timeout.InfiniteTimeSpan
+        };
         _globalAuthProvider = httpOptions.AuthProvider;
         _ownsClient = true;
     }
@@ -84,9 +89,18 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader, IDisposable
                 : null;
             var effectiveCt = linkedCts?.Token ?? cancellationToken;
 
+            // Use RequestTimeout for the HEAD probe (quick server info check)
+            using var probeCts = _httpOptions != null
+                ? new CancellationTokenSource(_httpOptions.RequestTimeout)
+                : null;
+            using var probeLinkedCts = probeCts != null
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, probeCts.Token)
+                : null;
+            var probeCt = probeLinkedCts?.Token ?? cancellationToken;
+
             var remoteInfo = await WithRetryAsync(
                 ct => GetRemoteInfoAsync(packageInfo, ct),
-                effectiveCt).ConfigureAwait(false);
+                probeCt).ConfigureAwait(false);
             var expectedMetadata = CreateMetadata(packageInfo, finalName, remoteInfo);
 
             var canResume = await EnsureResumeConsistencyAsync(tempFilePath, sidecarPath, expectedMetadata, cancellationToken).ConfigureAwait(false);
@@ -250,8 +264,14 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader, IDisposable
                 packageInfo.BasicUsername,
                 packageInfo.BasicPassword);
         }
-        else if (_globalAuthProvider != null)
+
+        // Fall back to global auth when per-package is not set or not configured
+        if ((provider is null || provider is NoOpAuthProvider) && _globalAuthProvider != null)
         {
+            if (packageInfo.AuthScheme.HasValue)
+            {
+                _logger.LogWarning($"AuthScheme '{packageInfo.AuthScheme}' is set but credentials are missing. Falling back to global auth provider.");
+            }
             provider = _globalAuthProvider;
         }
 

--- a/src/GeneralUpdate.Avalonia.Android/Services/HttpResumableApkDownloader.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Services/HttpResumableApkDownloader.cs
@@ -3,11 +3,12 @@ using System.Net.Http.Headers;
 using System.Diagnostics;
 using System.Text.Json;
 using GeneralUpdate.Avalonia.Android.Abstractions;
+using GeneralUpdate.Avalonia.Android.Enums;
 using GeneralUpdate.Avalonia.Android.Models;
 
 namespace GeneralUpdate.Avalonia.Android.Services;
 
-public sealed class HttpResumableApkDownloader : IUpdateDownloader
+public sealed class HttpResumableApkDownloader : IUpdateDownloader, IDisposable
 {
     private static readonly HashSet<char> InvalidFileNameChars = Path.GetInvalidFileNameChars().ToHashSet();
 
@@ -17,12 +18,39 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
     private readonly IUpdateLogger _logger;
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
 
+    private readonly HttpDownloadOptions? _httpOptions;
+    private readonly IHttpAuthProvider? _globalAuthProvider;
+    private readonly bool _ownsClient;
+
+    /// <summary>
+    /// Creates a downloader with an externally-provided HttpClient.
+    /// No authentication or custom HTTP options are applied.
+    /// </summary>
     public HttpResumableApkDownloader(HttpClient httpClient, IFileStorage fileStorage, AndroidUpdateOptions options, IUpdateLogger? logger = null)
     {
-        _httpClient = httpClient;
-        _fileStorage = fileStorage;
-        _options = options;
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _fileStorage = fileStorage ?? throw new ArgumentNullException(nameof(fileStorage));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? new NoOpUpdateLogger();
+        _httpOptions = null;
+        _globalAuthProvider = null;
+    }
+
+    /// <summary>
+    /// Creates a downloader with HTTP options that configure SSL, proxy, auth, and timeouts.
+    /// The HttpClient is constructed internally from the provided options.
+    /// </summary>
+    internal HttpResumableApkDownloader(IFileStorage fileStorage, AndroidUpdateOptions options, HttpDownloadOptions httpOptions, IUpdateLogger? logger = null)
+    {
+        _fileStorage = fileStorage ?? throw new ArgumentNullException(nameof(fileStorage));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _httpOptions = httpOptions ?? throw new ArgumentNullException(nameof(httpOptions));
+        _logger = logger ?? new NoOpUpdateLogger();
+
+        var handler = httpOptions.BuildHandler();
+        _httpClient = new HttpClient(handler, disposeHandler: true);
+        _globalAuthProvider = httpOptions.AuthProvider;
+        _ownsClient = true;
     }
 
     public async Task<DownloadResult> DownloadAsync(UpdatePackageInfo packageInfo, Action<DownloadProgressInfo>? progressCallback, CancellationToken cancellationToken = default)
@@ -47,7 +75,18 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
             var tempFilePath = finalFilePath + _options.TemporaryFileExtension;
             var sidecarPath = tempFilePath + _options.SidecarExtension;
 
-            var remoteInfo = await GetRemoteInfoAsync(packageInfo.DownloadUrl, cancellationToken).ConfigureAwait(false);
+            // Resolve download timeout: use configured value or infinite
+            using var timeoutCts = _httpOptions != null
+                ? new CancellationTokenSource(_httpOptions.DownloadTimeout)
+                : null;
+            using var linkedCts = timeoutCts != null
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token)
+                : null;
+            var effectiveCt = linkedCts?.Token ?? cancellationToken;
+
+            var remoteInfo = await WithRetryAsync(
+                ct => GetRemoteInfoAsync(packageInfo, ct),
+                effectiveCt).ConfigureAwait(false);
             var expectedMetadata = CreateMetadata(packageInfo, finalName, remoteInfo);
 
             var canResume = await EnsureResumeConsistencyAsync(tempFilePath, sidecarPath, expectedMetadata, cancellationToken).ConfigureAwait(false);
@@ -65,7 +104,9 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
                 request.Headers.Range = new RangeHeaderValue(existingLength, null);
             }
 
-            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            await ApplyAuthAsync(request, packageInfo, effectiveCt).ConfigureAwait(false);
+
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, effectiveCt).ConfigureAwait(false);
             if (existingLength > 0 && response.StatusCode == HttpStatusCode.OK)
             {
                 _logger.LogWarning("Server did not honor range request. Restarting download from zero.");
@@ -84,7 +125,7 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
 
             await _fileStorage.WriteAllTextAsync(sidecarPath, JsonSerializer.Serialize(metadataWithResponse), cancellationToken).ConfigureAwait(false);
 
-            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using var contentStream = await response.Content.ReadAsStreamAsync(effectiveCt).ConfigureAwait(false);
             await using var fileStream = _fileStorage.OpenWrite(tempFilePath, append: existingLength > 0);
 
             var buffer = new byte[_options.DownloadBufferSize];
@@ -95,7 +136,7 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
 
             while (true)
             {
-                var read = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                var read = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length), effectiveCt).ConfigureAwait(false);
                 if (read <= 0)
                 {
                     break;
@@ -177,9 +218,10 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
         }
     }
 
-    private async Task<(string? ETag, string? LastModified, long? ContentLength, bool AcceptRanges)> GetRemoteInfoAsync(string downloadUrl, CancellationToken cancellationToken)
+    private async Task<(string? ETag, string? LastModified, long? ContentLength, bool AcceptRanges)> GetRemoteInfoAsync(UpdatePackageInfo packageInfo, CancellationToken cancellationToken)
     {
-        using var headRequest = new HttpRequestMessage(HttpMethod.Head, downloadUrl);
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, packageInfo.DownloadUrl);
+        await ApplyAuthAsync(headRequest, packageInfo, cancellationToken).ConfigureAwait(false);
         using var headResponse = await _httpClient.SendAsync(headRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (!headResponse.IsSuccessStatusCode)
         {
@@ -193,6 +235,72 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
             headResponse.Content.Headers.ContentLength,
             acceptRanges);
     }
+
+    private async Task ApplyAuthAsync(HttpRequestMessage request, UpdatePackageInfo packageInfo, CancellationToken cancellationToken)
+    {
+        IHttpAuthProvider? provider = null;
+
+        // Per-package auth takes precedence
+        if (packageInfo.AuthScheme.HasValue)
+        {
+            provider = HttpAuthProviderFactory.Create(
+                packageInfo.AuthScheme.Value,
+                packageInfo.AuthToken,
+                packageInfo.AuthSecretKey,
+                packageInfo.BasicUsername,
+                packageInfo.BasicPassword);
+        }
+        else if (_globalAuthProvider != null)
+        {
+            provider = _globalAuthProvider;
+        }
+
+        if (provider != null)
+        {
+            await provider.ApplyAuthAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<T> WithRetryAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken)
+    {
+        if (_httpOptions == null || _httpOptions.MaxRetryAttempts <= 1)
+        {
+            return await action(cancellationToken).ConfigureAwait(false);
+        }
+
+        var maxAttempts = _httpOptions.MaxRetryAttempts;
+
+        for (var attempt = 0; ; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                return await action(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (attempt < maxAttempts - 1 && IsTransient(ex))
+            {
+                var delay = TimeSpan.FromMilliseconds(
+                    _httpOptions.RetryBaseDelay.TotalMilliseconds * Math.Pow(2, attempt));
+                _logger.LogWarning($"Download attempt {attempt + 1} failed with transient error. Retrying in {delay.TotalMilliseconds}ms. {ex.GetType().Name}: {ex.Message}");
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsTransient(Exception ex) => ex switch
+    {
+        TimeoutException => true,
+        OperationCanceledException => false,
+        IOException ioe when ioe.InnerException is TimeoutException => true,
+        HttpRequestException hre => hre.StatusCode is
+            HttpStatusCode.RequestTimeout or
+            HttpStatusCode.InternalServerError or
+            HttpStatusCode.BadGateway or
+            HttpStatusCode.ServiceUnavailable or
+            HttpStatusCode.GatewayTimeout,
+        _ => false
+    };
 
     private async Task<bool> EnsureResumeConsistencyAsync(
         string tempFilePath,
@@ -313,6 +421,14 @@ public sealed class HttpResumableApkDownloader : IUpdateDownloader
         }
 
         return sanitized;
+    }
+
+    public void Dispose()
+    {
+        if (_ownsClient)
+        {
+            _httpClient.Dispose();
+        }
     }
 
     private sealed class SmoothedSpeedMeter

--- a/src/GeneralUpdate.Avalonia.Android/Services/SslValidationPolicies.cs
+++ b/src/GeneralUpdate.Avalonia.Android/Services/SslValidationPolicies.cs
@@ -1,0 +1,33 @@
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using GeneralUpdate.Avalonia.Android.Abstractions;
+
+namespace GeneralUpdate.Avalonia.Android.Services;
+
+/// <summary>
+/// Strict SSL validation policy: only accepts certificates with no policy errors.
+/// This is the default and recommended policy for production use.
+/// </summary>
+public sealed class StrictSslValidationPolicy : ISslValidationPolicy
+{
+    public bool ValidateCertificate(
+        X509Certificate2? certificate,
+        X509Chain? chain,
+        SslPolicyErrors sslPolicyErrors)
+        => sslPolicyErrors == SslPolicyErrors.None;
+}
+
+/// <summary>
+/// Permissive SSL validation policy: accepts all certificates regardless of errors.
+/// WARNING: This bypasses certificate validation and should ONLY be used
+/// in development/testing environments with self-signed certificates.
+/// Never use this in production.
+/// </summary>
+public sealed class AllowAllSslValidationPolicy : ISslValidationPolicy
+{
+    public bool ValidateCertificate(
+        X509Certificate2? certificate,
+        X509Chain? chain,
+        SslPolicyErrors sslPolicyErrors)
+        => true;
+}

--- a/tests/GeneralUpdate.Avalonia.Android.Tests/GeneralUpdate.Avalonia.Android.Tests.csproj
+++ b/tests/GeneralUpdate.Avalonia.Android.Tests/GeneralUpdate.Avalonia.Android.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="../../src/GeneralUpdate.Avalonia.Android/Abstractions/IUpdateEventDispatcher.cs" Link="Source/Abstractions/IUpdateEventDispatcher.cs" />
     <Compile Include="../../src/GeneralUpdate.Avalonia.Android/Abstractions/IUpdateLogger.cs" Link="Source/Abstractions/IUpdateLogger.cs" />
     <Compile Include="../../src/GeneralUpdate.Avalonia.Android/Abstractions/IVersionComparer.cs" Link="Source/Abstractions/IVersionComparer.cs" />
+    <Compile Include="../../src/GeneralUpdate.Avalonia.Android/Enums/AuthScheme.cs" Link="Source/Enums/AuthScheme.cs" />
     <Compile Include="../../src/GeneralUpdate.Avalonia.Android/Enums/UpdateFailureReason.cs" Link="Source/Enums/UpdateFailureReason.cs" />
     <Compile Include="../../src/GeneralUpdate.Avalonia.Android/Enums/UpdateState.cs" Link="Source/Enums/UpdateState.cs" />
     <Compile Include="../../src/GeneralUpdate.Avalonia.Android/Events/DownloadProgressChangedEventArgs.cs" Link="Source/Events/DownloadProgressChangedEventArgs.cs" />


### PR DESCRIPTION
## Summary

Adds HTTP/HTTPS compatibility features (SSL validation, proxy, timeouts, retry) and multiple authentication methods (Bearer, Basic, ApiKey, HMAC) to GeneralUpdate.Avalonia.Android.

## Changes

### New files (6)
- `IHttpAuthProvider` + `ISslValidationPolicy` interfaces
- `AuthScheme` enum (Hmac/Bearer/ApiKey/Basic)
- 5 auth providers (NoOp, BearerToken, ApiKey, Basic, Hmac) + `HttpAuthProviderFactory`
- `StrictSslValidationPolicy` / `AllowAllSslValidationPolicy`
- `HttpDownloadOptions` configuration record

### Modified files (4)
- **UpdatePackageInfo.cs** — 5 nullable auth fields for per-package authentication (overrides global)
- **HttpResumableApkDownloader.cs** — Auth injection into HEAD/GET requests, exponential backoff retry, download timeout, IDisposable
- **GeneralUpdateBootstrap.cs** — Optional `HttpDownloadOptions` parameter
- **AndroidBootstrap.cs** — Disposes downloader if IDisposable

### Design
- Fully backward-compatible (all new params optional, default behavior identical)
- Auth priority: per-package > global > none
- Instance-based (no static global state)
- No dependency on GeneralUpdate.Core

## Related Issue
Closes #14

## Verification
- ✅ Library builds: 0 warnings, 0 errors
- ✅ All 4 existing unit tests pass
- ✅ Test project builds: 0 warnings, 0 errors